### PR TITLE
Feature: Generate sql helper funcs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install or upgrade Scaneo with this command.
 go get -u github.com/variadico/scaneo
 ```
 
-Otherwise, check out the 
+Otherwise, check out the
 [releases page](https://github.com/variadico/scaneo/releases/latest).
 
 ## Usage
@@ -35,6 +35,9 @@ scaneo [options] paths...
 -w, -whitelist
     Only include structs specified in case-sensitive, comma-delimited
     string.
+
+-f, -funcs
+    Generate SQL helper functions. Default is false.
 
 -v, -version
     Print version and exit.


### PR DESCRIPTION
Adds flag option to generate sql helper funcs, for example given:
```go
//go:generate scaneo -u -p user -f -o scaneo.go $GOFILE
package storage

import (
	"time"
)

// User represents a user model in the database
type User struct {
	ID      int
	Name    string
	Email   string
	Created time.Time
	Updated time.Time
	Deleted time.Time
}
```
It will generate:
```go
// SelectUser selects a single User row from the database
func SelectUser(db *sql.DB, query string, args ...interface{}) (*User, error) {
	row := db.QueryRow(query, args...)
	return scanUser(row)
}

// SelectUsers selects multiple User rows from the database
func SelectUsers(db *sql.DB, query string, args ...interface{}) ([]*User, error) {
	rows, err := db.Query(query, args...)
	if err != nil {
		return nil, err
	}
	defer rows.Close()
	return scanUsers(rows)
}

// sliceUser returns a slice of arguments from User struct values
func sliceUser(v *User) []interface{} {
	return []interface{}{
		&v.ID,
	}
}

// InsertUser inserts a single User row
func InsertUser(db *sql.DB, query string, v *User) error {
	_, err := db.Exec(query, sliceUser(v)[1:]...)
	return err
}

// UpdateUser updates a single User row
func UpdateUser(db *sql.DB, query string, v *User) error {
	args := sliceUser(v)[1:]
	args = append(args, v.ID)
	_, err := db.Exec(query, args...)
	return err
}
```