### PR TITLE
Feature: Import config

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ scaneo [options] paths...
 -f, -funcs
     Generate SQL helper functions. Default is false.
 
+-i, -import
+    Override package to import type from.
+
 -v, -version
     Print version and exit.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Install or upgrade Scaneo with this command.
 go get -u github.com/variadico/scaneo
 ```
 
-Otherwise, check out the 
+Otherwise, check out the
 [releases page](https://github.com/variadico/scaneo/releases/latest).
 
 ## Usage
@@ -35,6 +35,9 @@ scaneo [options] paths...
 -w, -whitelist
     Only include structs specified in case-sensitive, comma-delimited
     string.
+
+-f, -funcs
+    Generate SQL helper functions. Default is false.
 
 -v, -version
     Print version and exit.

--- a/scaneo_test.go
+++ b/scaneo_test.go
@@ -314,6 +314,7 @@ func TestGenFile(t *testing.T) {
 		tokens        []structToken
 		unexport      bool
 		funcs         bool
+		pkgImport     string
 		assert        func(*testing.T, error)
 		expectedFuncs []string
 	}{
@@ -323,6 +324,7 @@ func TestGenFile(t *testing.T) {
 			[]structToken{},
 			true,
 			false,
+			"",
 			func(t *testing.T, err error) {
 				if err == nil {
 					t.Error("no struct tokens passed")
@@ -338,6 +340,7 @@ func TestGenFile(t *testing.T) {
 			toks,
 			true,
 			false,
+			"",
 			func(t *testing.T, err error) {
 				if err == nil {
 					t.Error("no output file path passed")
@@ -353,6 +356,7 @@ func TestGenFile(t *testing.T) {
 			toks,
 			true,
 			false,
+			"",
 			func(t *testing.T, err error) {
 				if err != nil {
 					t.Error(err)
@@ -367,6 +371,7 @@ func TestGenFile(t *testing.T) {
 			toks,
 			true,
 			true,
+			"",
 			func(t *testing.T, err error) {
 				if err != nil {
 					t.Error(err)
@@ -390,6 +395,21 @@ func TestGenFile(t *testing.T) {
 				"UpdateUnexported",
 			},
 		},
+		{
+			"pkg import",
+			true,
+			toks,
+			true,
+			false,
+			"testsvc/storage/user",
+			func(t *testing.T, err error) {
+				if err != nil {
+					t.Error(err)
+					t.FailNow()
+				}
+			},
+			expectedFuncNames,
+		},
 	}
 
 	for _, tc := range tt {
@@ -401,7 +421,7 @@ func TestGenFile(t *testing.T) {
 					fmt.Sprintf("scaneo-test-%d", time.Now().UnixNano()))
 			}
 			// genFile(file, package, unexport, tokens, funcs)
-			err := genFile(outFile, "testing", tc.unexport, tc.tokens, tc.funcs)
+			err := genFile(outFile, "testing", tc.unexport, tc.tokens, tc.funcs, tc.pkgImport)
 			defer os.Remove(outFile) // comment this line to examine generated code
 
 			tc.assert(t, err)

--- a/tmpl.go
+++ b/tmpl.go
@@ -5,23 +5,26 @@ const (
 
 package {{.PackageName}}
 
-import "database/sql"
-
-{{range .Tokens}}func {{$.Visibility}}can{{title .Name}}(r *sql.Row) (*{{.Name}}, error) {
-	var s *{{.Name}}
+import (
+	"database/sql"{{ if .ImportPkg }}
+	"{{.ImportPkg}}"{{end}}
+)
+{{range .Tokens}}
+func {{$.Visibility}}can{{title .Name}}(r *sql.Row) (*{{pkg .Name}}, error) {
+	var s *{{pkg .Name}}
 	if err := r.Scan({{range .Fields}}
 		&s.{{.Name}},{{end}}
 	); err != nil {
-		return &{{.Name}}{}, err
+		return &{{pkg .Name}}{}, err
 	}
 	return s, nil
 }
 
-func {{$.Visibility}}can{{title .Name}}s(rs *sql.Rows) ([]*{{.Name}}, error) {
-	structs := make([]*{{.Name}}, 0, 16)
+func {{$.Visibility}}can{{title .Name}}s(rs *sql.Rows) ([]*{{pkg .Name}}, error) {
+	structs := make([]*{{pkg .Name}}, 0, 16)
 	var err error
 	for rs.Next() {
-		var s *{{.Name}}
+		var s *{{pkg .Name}}
 		if err = rs.Scan({{range .Fields}}
 			&s.{{.Name}},{{end}}
 		); err != nil {
@@ -36,13 +39,13 @@ func {{$.Visibility}}can{{title .Name}}s(rs *sql.Rows) ([]*{{.Name}}, error) {
 }
 {{if $.Funcs}}
 // Select{{title .Name}} selects a single {{title .Name}} row from the database
-func Select{{title .Name}}(db *sql.DB, query string, args ...interface{}) (*{{title .Name}}, error) {
+func Select{{title .Name}}(db *sql.DB, query string, args ...interface{}) (*{{pkg .Name}}, error) {
 	row := db.QueryRow(query, args...)
 	return {{$.Visibility}}can{{title .Name}}(row)
 }
 
 // Select{{title .Name}}s selects multiple {{title .Name}} rows from the database
-func Select{{title .Name}}s(db *sql.DB, query string, args ...interface{}) ([]*{{title .Name}}, error) {
+func Select{{title .Name}}s(db *sql.DB, query string, args ...interface{}) ([]*{{pkg .Name}}, error) {
 	rows, err := db.Query(query, args...)
 	if err != nil {
 		return nil, err
@@ -52,25 +55,24 @@ func Select{{title .Name}}s(db *sql.DB, query string, args ...interface{}) ([]*{
 }
 
 // slice{{title .Name}} returns a slice of arguments from {{title .Name}} struct values
-func slice{{title .Name}}(v *{{title .Name}}) []interface{} {
+func slice{{title .Name}}(v *{{pkg .Name}}) []interface{} {
 	return []interface{}{ {{range .Fields}}
 		&v.{{.Name}},{{end}}
 	}
 }
 
 // Insert{{title .Name}} inserts a single {{title .Name}} row
-func Insert{{title .Name}}(db *sql.DB, query string, v *{{title .Name}}) error {
+func Insert{{title .Name}}(db *sql.DB, query string, v *{{pkg .Name}}) error {
 	_, err := db.Exec(query, slice{{title .Name}}(v)[1:]...)
 	return err
 }
 
 // Update{{title .Name}} updates a single {{title .Name}} row
-func Update{{title .Name}}(db *sql.DB, query string, v *{{title .Name}}) error {
+func Update{{title .Name}}(db *sql.DB, query string, v *{{pkg .Name}}) error {
 	args := slice{{title .Name}}(v)[1:]
 	args = append(args, v.ID)
 	_, err := db.Exec(query, args...)
 	return err
 }
-
 {{end}}{{end}}{{end}}`
 )


### PR DESCRIPTION
Depends on #1 being merged first.

Adds option to override import path of type so it could be used in a separate package. For example:
```go
//go:generate scaneo -u -p user -f -i usersvc/storage -o psql/user/scaneo.go $GOFILE
package storage

import (
	"time"
)

// User represents a user model in the database
type User struct {
	ID      int
	Name    string
	Email   string
	Created time.Time
	Updated time.Time
	Deleted time.Time
}
```

results in `storage.User`:
```
// DON'T EDIT *** generated by scaneo *** DON'T EDIT //

package user

import (
	"database/sql"
	"usersvc/storage"
)

func scanUser(r *sql.Row) (*storage.User, error) {
	var s *storage.User
	if err := r.Scan(
		&s.ID,
		&s.Name,
		&s.Email,
		&s.Created,
		&s.Updated,
		&s.Deleted,
	); err != nil {
		return &storage.User{}, err
	}
	return s, nil
}

func scanUsers(rs *sql.Rows) ([]*storage.User, error) {
	structs := make([]*storage.User, 0, 16)
	var err error
	for rs.Next() {
		var s *storage.User
		if err = rs.Scan(
			&s.ID,
			&s.Name,
			&s.Email,
			&s.Created,
			&s.Updated,
			&s.Deleted,
		); err != nil {
			return nil, err
		}
		structs = append(structs, s)
	}
	if err = rs.Err(); err != nil {
		return nil, err
	}
	return structs, nil
}

// SelectUser selects a single User row from the database
func SelectUser(db *sql.DB, query string, args ...interface{}) (*storage.User, error) {
	row := db.QueryRow(query, args...)
	return scanUser(row)
}

// SelectUsers selects multiple User rows from the database
func SelectUsers(db *sql.DB, query string, args ...interface{}) ([]*storage.User, error) {
	rows, err := db.Query(query, args...)
	if err != nil {
		return nil, err
	}
	defer rows.Close()
	return scanUsers(rows)
}

// sliceUser returns a slice of arguments from User struct values
func sliceUser(v *storage.User) []interface{} {
	return []interface{}{ 
		&v.ID,
		&v.Name,
		&v.Email,
		&v.Created,
		&v.Updated,
		&v.Deleted,
	}
}

// InsertUser inserts a single User row
func InsertUser(db *sql.DB, query string, v *storage.User) error {
	_, err := db.Exec(query, sliceUser(v)[1:]...)
	return err
}

// UpdateUser updates a single User row
func UpdateUser(db *sql.DB, query string, v *storage.User) error {
	args := sliceUser(v)[1:]
	args = append(args, v.ID)
	_, err := db.Exec(query, args...)
	return err
}
```